### PR TITLE
Adding similarChars and prefix options

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,12 @@
 									Special characters
 								</label>
 							</div>
+							<div class="checkbox">
+								<label>
+									<input type="checkbox" data-ng-model="options.similarChars">
+									Similar/Ambiguous characters
+								</label>
+							</div>
 							<div class="form-group">
 								<label for="password">
 									Password Length
@@ -85,7 +91,7 @@
 								<label for="password">Password</label>
 								<input type="text" name="password" id="password" class="form-control" placeholder="Password" data-ng-model="passwordField">
 							</div>
-							<password-generator class="btn btn-primary" field="passwordField" button-text="Click to generate" password-length="options.passwordLength" uppercase="options.uppercase" numbers="options.numbers" specials="options.specials"></password-generator>
+							<password-generator class="btn btn-primary" field="passwordField" button-text="Click to generate" password-length="options.passwordLength" uppercase="options.uppercase" numbers="options.numbers" specials="options.specials" data-similar-chars="options.similarChars"></password-generator>
 
 						</div>
 						<div class="panel-body">
@@ -93,7 +99,7 @@
 							<div class="input-group">
 								<input type="text" name="password2" id="password2" class="form-control" placeholder="Password" data-ng-model="passwordField2">
 								<span class="input-group-btn">
-									<button type="button" class="btn btn-default" data-password-generator data-field="passwordField2" data-button-text="Generate" data-password-length="options.passwordLength" data-uppercase="options.uppercase" data-numbers="options.numbers" data-specials="options.specials"></button>
+									<button type="button" class="btn btn-default" data-password-generator data-field="passwordField2" data-button-text="Generate" data-password-length="options.passwordLength" data-uppercase="options.uppercase" data-numbers="options.numbers" data-specials="options.specials" data-similar-chars="options.similarChars"></button>
 								</span>
 							</div>
 						</div>

--- a/index.html
+++ b/index.html
@@ -72,6 +72,10 @@
 								</label>
 							</div>
 							<div class="form-group">
+								<label for="prefix">Prefix</label>
+								<input type="input" data-ng-model="options.prefix">
+							</div>
+							<div class="form-group">
 								<label for="password">
 									Password Length
 									<span class="badge">{{ options.passwordLength }}</span>
@@ -91,7 +95,7 @@
 								<label for="password">Password</label>
 								<input type="text" name="password" id="password" class="form-control" placeholder="Password" data-ng-model="passwordField">
 							</div>
-							<password-generator class="btn btn-primary" field="passwordField" button-text="Click to generate" password-length="options.passwordLength" uppercase="options.uppercase" numbers="options.numbers" specials="options.specials" data-similar-chars="options.similarChars"></password-generator>
+							<password-generator class="btn btn-primary" field="passwordField" button-text="Click to generate" password-length="options.passwordLength" uppercase="options.uppercase" numbers="options.numbers" specials="options.specials" data-similar-chars="options.similarChars" data-prefix="options.prefix"></password-generator>
 
 						</div>
 						<div class="panel-body">
@@ -99,7 +103,7 @@
 							<div class="input-group">
 								<input type="text" name="password2" id="password2" class="form-control" placeholder="Password" data-ng-model="passwordField2">
 								<span class="input-group-btn">
-									<button type="button" class="btn btn-default" data-password-generator data-field="passwordField2" data-button-text="Generate" data-password-length="options.passwordLength" data-uppercase="options.uppercase" data-numbers="options.numbers" data-specials="options.specials" data-similar-chars="options.similarChars"></button>
+									<button type="button" class="btn btn-default" data-password-generator data-field="passwordField2" data-button-text="Generate" data-password-length="options.passwordLength" data-uppercase="options.uppercase" data-numbers="options.numbers" data-specials="options.specials" data-similar-chars="options.similarChars" data-prefix="options.prefix"></button>
 								</span>
 							</div>
 						</div>

--- a/ng-password-generator.js
+++ b/ng-password-generator.js
@@ -15,6 +15,7 @@ angular
 
 		$scope.options = {
 			passwordLength: 8,
+			prefix: '',
 			uppercase: true,
 			numbers: true,
 			specials: true,
@@ -30,6 +31,7 @@ angular
 			scope: {
 				field: '=field',
 				passwordLength: '=?passwordLength',
+				prefix: '=?prefix',
 				uppercase: '=?uppercase',
 				numbers: '=?numbers',
 				specials: '=?specials',
@@ -41,6 +43,7 @@ angular
 
 				// Initialize the default values
 				scope.passwordLength = (scope.passwordLength) ? scope.passwordLength : 8;
+				scope.prefix = (scope.prefix) ? scope.prefix : '';
 				scope.uppercase = (scope.uppercase) ? scope.uppercase : false;
 				scope.numbers = (scope.numbers) ? scope.numbers : false;
 				scope.specials = (scope.specials) ? scope.specials : false;
@@ -86,7 +89,7 @@ angular
 					}
 
 					// Save the result on field
-					scope.field = finalPassword.join('');
+					scope.field = scope.prefix+finalPassword.join('');
 
 				};
 

--- a/ng-password-generator.js
+++ b/ng-password-generator.js
@@ -17,7 +17,8 @@ angular
 			passwordLength: 8,
 			uppercase: true,
 			numbers: true,
-			specials: true
+			specials: true,
+			similarChars: true
 		};
 
 	}])
@@ -32,6 +33,7 @@ angular
 				uppercase: '=?uppercase',
 				numbers: '=?numbers',
 				specials: '=?specials',
+				similarChars: '=?similarChars',
 				buttonText: '@?buttonText'
 			},
 			template: '<button type="button" data-ng-click="generatePassword()">{{ buttonText }}</button>',
@@ -42,16 +44,24 @@ angular
 				scope.uppercase = (scope.uppercase) ? scope.uppercase : false;
 				scope.numbers = (scope.numbers) ? scope.numbers : false;
 				scope.specials = (scope.specials) ? scope.specials : false;
+				scope.similarChars = (scope.similarChars) ? scope.similarChars : false;
 				scope.buttonText = (scope.buttonText !== undefined) ? scope.buttonText : 'Generate password';
 
 				// Enable password generation
 				scope.generatePassword = function() {
 
 					// Create variables with characters, numbers and special
-					var lowerCharacters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'],
-						upperCharacters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
-						numbers = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
-						specials = ['!', '"', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~'];
+					var lowerCharacters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'],
+						upperCharacters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
+						numbers = ['2', '3', '4', '5', '6', '7', '8', '9'],
+						specials = ['!', '"', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '}', '~'];
+
+					if (scope.similarChars) {
+						lowerCharacters = lowerCharacters.concat(['i', 'l', 'o']);
+						upperCharacters = upperCharacters.concat(['I', 'O']);
+						numbers = numbers.concat(['0', '1']);
+						specials = specials.concat(['|']);
+					}
 
 					// Concatenate the differents variables according to true/false
 					var finalCharacters = lowerCharacters;


### PR DESCRIPTION
- 'similarChars' is an option to include/exclude the characters "iloIO01|" which can be ambiguous, depending on the font. By default similarChars is true.

- 'prefix' allows users to prefix all generated passwords with the same string. For example, data-prefix="live_" will cause all generated passwords to start with "live_". Note the prefix does NOT count towards the passwordLength.

I changed these locally for my own project and thought they might be worthwhile options to push to your repo. I updated the index.html to use the new options, but did not update the readme with additional documentation. I can do that too if you'd like.

-Noah